### PR TITLE
Added Digital Devices (manufacturer), changed dvdbsky (corrections an…

### DIFF
--- a/distributions/LibreELEC/options
+++ b/distributions/LibreELEC/options
@@ -60,7 +60,8 @@
 # for a list of additinoal drivers see packages/linux-drivers
 # Space separated list is supported,
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8812AU dvbhdhomerun tbs tbs-dvbc tbs-oss crazycat media_build ljalves-cc dddvb dvbsky"
+  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8812AU dvbhdhomerun tbs tbs-dvbc tbs-oss crazycat media_build ljalves-cc dddvb digital_devices"
+# dvbsky temporarily disabled untill fixed
 
 # build and install bluetooth support (yes / no)
   BLUETOOTH_SUPPORT="yes"

--- a/packages/addons/script/script.dvb.driver/addon/changelog.txt
+++ b/packages/addons/script/script.dvb.driver/addon/changelog.txt
@@ -1,3 +1,6 @@
+1.4
+- Add Digital Devices (manufacturer) support
+
 1.3
 - fix incorrect Digital Devices name in dvb-driver.txt
 

--- a/packages/addons/script/script.dvb.driver/addon/default.py
+++ b/packages/addons/script/script.dvb.driver/addon/default.py
@@ -88,6 +88,12 @@ def dvbsky():
 	LF.close()
 	reboot()
 
+def digital_devices():
+  LF = open('/storage/downloads/dvb-drivers.txt', 'w')
+  LF.write('4.4.7-digital_devices')
+  LF.close()
+  reboot()
+
 try:
 	args = ' '.join(sys.argv[1:])
 except:
@@ -109,7 +115,9 @@ elif args == 'mediabuild':
 	mediabuild()
 elif args == 'dddvbcc':
 	dddvbcc()
-elif args == 'dvbsky':
-	dddvbcc()
+elif args == 'dvbskyc':
+	dvbsky()
+elif args == 'digital_devices':
+  digital_devices()
 else:
 	xbmc.executebuiltin('Addon.OpenSettings(script.dvb.driver)')

--- a/packages/addons/script/script.dvb.driver/addon/resources/settings.xml
+++ b/packages/addons/script/script.dvb.driver/addon/resources/settings.xml
@@ -7,6 +7,7 @@
         <setting label="Official TBS OSS Drivers (TBS6205,6904,6909)" type="action" action="RunScript(script.dvb.driver, tbs_oss)"/>
         <setting label="CrazyCat (Official TBS Driver + additions)" type="action" action="RunScript(script.dvb.driver, crazycat)"/>
         <setting label="Digital Devices" type="action" action="RunScript(script.dvb.driver, dddvbcc)"/>
+        <setting label="Digital Devices (manufacturer)" type="action" action="RunScript(script.dvb.driver, digital_devices)"/>
         <setting label="DVBSky DVB-C Drivers" type="action" action="RunScript(script.dvb.driver, dvbskyc)"/>
         <setting label="[Generic and Rpi1/2/3] TBS Cards - Open Source Drivers" type="lsep"/>
         <setting label="Ljalves-CC Drivers (Ljalves + additions from CrazyCat)" type="action" action="RunScript(script.dvb.driver, ljalvescc)"/>

--- a/packages/addons/script/script.dvb.driver/package.mk
+++ b/packages/addons/script/script.dvb.driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="script.dvb.driver"
-PKG_VERSION="1.3"
+PKG_VERSION="1.4"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"

--- a/packages/linux-dvb-drivers/digital_devices/future_kernel_4.6_patches/digital_devices-01_kernel-4.6.patch
+++ b/packages/linux-dvb-drivers/digital_devices/future_kernel_4.6_patches/digital_devices-01_kernel-4.6.patch
@@ -1,0 +1,50 @@
+diff -aur dddvb-0.9.23_original/ddbridge/octonet.c dddvb-0.9.23_patched/ddbridge/octonet.c
+--- dddvb-0.9.23_original/ddbridge/octonet.c	2016-04-11 18:26:36.000000000 +0200
++++ dddvb-0.9.23_patched/ddbridge/octonet.c	2016-05-27 14:27:36.023282591 +0200
+@@ -25,7 +25,7 @@
+ 
+ #include "ddbridge.h"
+ #include "ddbridge-regs.h"
+-#include <asm-generic/pci-dma-compat.h>
++#include <linux/pci-dma-compat.h>
+ 
+ static int adapter_alloc = 3;
+ module_param(adapter_alloc, int, 0444);
+diff -aur dddvb-0.9.23_original/frontends/drxk_hard.c dddvb-0.9.23_patched/frontends/drxk_hard.c
+--- dddvb-0.9.23_original/frontends/drxk_hard.c	2016-04-11 18:26:36.000000000 +0200
++++ dddvb-0.9.23_patched/frontends/drxk_hard.c	2016-05-27 14:36:28.039939664 +0200
+@@ -4990,12 +4990,12 @@
+ 	return 0;
+ }
+ 
+-static int drxk_t_get_frontend(struct dvb_frontend *fe, struct dvb_frontend_parameters *p)
+-{
++//static int drxk_t_get_frontend(struct dvb_frontend *fe, struct dvb_frontend_parameters *p)
++//{
+ 	//struct drxk_state *state = fe->demodulator_priv;
+ 	//printk("%s\n", __FUNCTION__);
+-	return 0;
+-}
++//	return 0;
++//}
+ 
+ static struct dvb_frontend_ops drxk_c_ops = {
+ 	.info = {
+@@ -5015,7 +5015,7 @@
+ 	.i2c_gate_ctrl = drxk_gate_ctrl,
+ 
+ 	.set_frontend = drxk_set_parameters,
+-	.get_frontend = drxk_c_get_frontend,
++//	.get_frontend = drxk_c_get_frontend,
+ 	.get_tune_settings = drxk_c_get_tune_settings,
+ 
+ 	.read_status = drxk_read_status,
+@@ -5049,7 +5049,7 @@
+ 	.i2c_gate_ctrl = drxk_gate_ctrl,
+ 
+ 	.set_frontend = drxk_set_parameters,
+-	.get_frontend = drxk_t_get_frontend,
++//	.get_frontend = drxk_t_get_frontend,
+ 
+ 	.read_status = drxk_read_status,
+ 	.read_ber = drxk_read_ber,

--- a/packages/linux-dvb-drivers/digital_devices/package.mk
+++ b/packages/linux-dvb-drivers/digital_devices/package.mk
@@ -1,0 +1,108 @@
+################################################################################
+#      This file is part of LibreELEC - https://LibreELEC.tv
+#      Copyright (C) 2016 Team LibreELEC
+#
+#  LibreELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  LibreELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with LibreELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="digital_devices"
+PKG_VERSION="0.9.23"
+PKG_REV="1"
+PKG_ARCH="x86_64"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/DigitalDevices/dddvb/releases/tag/${PKG_VERSION}"
+PKG_URL="https://github.com/DigitalDevices/dddvb/archive/${PKG_VERSION}.tar.gz"
+PKG_DEPENDS_TARGET=""
+PKG_BUILD_DEPENDS_TARGET="toolchain linux"
+PKG_PRIORITY="optional"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Linux Digital Devices manufacturer drivers"
+PKG_LONGDESC="Linux Digital Devices manufacturer drivers"
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+unpack() {
+  # Internally the source uses a different name than that of the package ...
+  mkdir $ROOT/$BUILD/$PKG_NAME-$PKG_VERSION
+  tar -xvf $ROOT/$SOURCES/$PKG_NAME/$PKG_SOURCE_NAME --strip-components=1 --directory=$ROOT/$BUILD/$PKG_NAME-$PKG_VERSION > /dev/null
+}
+
+make_target() {
+  KDIR=$(kernel_path) make
+}
+
+
+makeinstall_target() {
+  mkdir -p $INSTALL/lib/modules/$(get_module_dir)/updates/$PKG_NAME
+  find $ROOT/$PKG_BUILD/ -path $INSTALL -prune -o -name \*.ko -exec cp {} $INSTALL/lib/modules/$(get_module_dir)/updates/$PKG_NAME \;
+}
+
+pre_install() {
+  # modules are installed under this name
+  KNAME_THIS=$PKG_NAME
+  # compare with
+  KNAME_CMP=sys
+
+  KVER=$(get_module_dir)
+  KDIR_ROOT=$INSTALL/lib/modules/${KVER}
+  KDIR_SYS=$INSTALL/lib/modules/${KVER}-sys
+  KDIR_THIS=$INSTALL/lib/modules/${KVER}-$KNAME_THIS
+  KDIR_CMP=$INSTALL/lib/modules/${KVER}-$KNAME_CMP
+  echo "$KDIR_ROOT" "$KDIR_SYS"
+
+  if [ -d "$KDIR_SYS" ]; then
+    echo "folder $KDIR_SYS must not exist"
+    exit 1
+  fi
+
+  cp -aP "$KDIR_ROOT" "$KDIR_SYS"
+}
+
+post_install() {
+  find $KDIR_ROOT/* -type f -name *.ko | while read f1; do
+    f2=$(echo "$f1" | sed "s|$KDIR_ROOT/||")
+
+    if [ -f $KDIR_ROOT/$f2 -a -f $KDIR_CMP/$f2 ]; then
+      md5_new=$(md5sum $KDIR_ROOT/$f2 | cut -d ' ' -f1)
+      md5_cmp=$(md5sum $KDIR_CMP/$f2 | cut -d ' ' -f1)
+      if [ "$md5_new" = "$md5_cmp" ]; then
+        # use hard link from compared kernel
+        ln -f "$KDIR_CMP/$f2" "$KDIR_ROOT/$f2"
+      fi
+    fi
+
+    # todo: check if there can be symbolic link for module file
+  done
+
+  # run depmod
+  MODVER=${KVER}
+
+  find $INSTALL/lib/modules/$MODVER/ -name *.ko | \
+    sed -e "s,$INSTALL/lib/modules/$MODVER/,," > $INSTALL/lib/modules/$MODVER/modules.order
+  $ROOT/$TOOLCHAIN/bin/depmod -b $INSTALL $MODVER 2>/dev/null
+
+  # strip kernel modules
+  for MOD in $(find $INSTALL/lib/modules/$MODVER -type f -name *.ko); do
+    $STRIP --strip-debug $MOD || : # ignore
+  done
+
+  # rename to new folder
+  rm -fr "$KDIR_THIS"
+  mv "$KDIR_ROOT" "$KDIR_THIS"
+
+  # rename sys folder back
+  mv "$KDIR_SYS" "$KDIR_ROOT"
+
+  echo "${KVER}-$KNAME_THIS" >>$INSTALL/lib/modules/.kernel_modules_dir
+}


### PR DESCRIPTION
…d disabled)

Note: Distribution/options has 'dvbsky' disabled (did not compile)
Some errors for dvbsky in the script package have been addressed (not tested)

These Digital Devices sources are those where the manufacturer refers to:
http://support.digital-devices.eu/knowledgebase.php?article=152

Includes a future patch for the 4.6 kernel ... (directory rename needed for this)
