### PR TITLE
vdr-addon: don't stop vdr before kodi

### DIFF
--- a/packages/addons/service/vdr-addon/source/system.d/service.multimedia.vdr-addon.service
+++ b/packages/addons/service/vdr-addon/source/system.d/service.multimedia.vdr-addon.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=vdr
 After=graphical.target
+Before=kodi.service
 
 [Service]
 ExecStart=/bin/sh -c "exec sh /storage/.kodi/addons/service.multimedia.vdr-addon/bin/vdr.start"


### PR DESCRIPTION
On shutdown vdr may disconnect from kodi before PVR terminates. VNSI's reconnect try is delaying kodi's exit until systemd is killing kodi. At least setwakeup.sh is not executed in this case and the next recording may fail.

Adding the dependency is restoring smooth shutdown.