### PR TITLE
[LE13.0] mariadb: update to 12.2.1

### DIFF
--- a/packages/addons/service/mariadb/package.mk
+++ b/packages/addons/service/mariadb/package.mk
@@ -2,9 +2,9 @@
 # Copyright (C) 2018-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="mariadb"
-PKG_VERSION="11.8.5"
-PKG_REV="0"
-PKG_SHA256="bcb7394569c08877c283e1649869504531bee8caafa30288f078e30d99fcb9f6"
+PKG_VERSION="12.2.1"
+PKG_REV="1"
+PKG_SHA256="331fd389094789bde1ae789889cb7125b34584755056c8212a92e648eb2e515b"
 PKG_LICENSE="GPL2"
 PKG_SITE="https://mariadb.org"
 PKG_URL="https://archive.mariadb.org/${PKG_NAME}-${PKG_VERSION}/source/${PKG_NAME}-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Automated update of mariadb to version 12.2.1 using tools/update-pkg.