### PR TITLE
[LE13.0] libpcap: update to 1.10.6

### DIFF
--- a/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
+++ b/packages/addons/addon-depends/network-tools-depends/depends/libpcap/package.mk
@@ -2,8 +2,8 @@
 # Copyright (C) 2016-present Team LibreELEC (https://libreelec.tv)
 
 PKG_NAME="libpcap"
-PKG_VERSION="1.10.5"
-PKG_SHA256="37ced90a19a302a7f32e458224a00c365c117905c2cd35ac544b6880a81488f0"
+PKG_VERSION="1.10.6"
+PKG_SHA256="872dd11337fe1ab02ad9d4fee047c9da244d695c6ddf34e2ebb733efd4ed8aa9"
 PKG_LICENSE="GPL"
 PKG_SITE="https://www.tcpdump.org/"
 PKG_URL="https://www.tcpdump.org/release/libpcap-${PKG_VERSION}.tar.gz"


### PR DESCRIPTION
Automated update of libpcap to version 1.10.6 using tools/update-pkg.